### PR TITLE
Created jsdoc API documentation and grunt automation for eslint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules/*
 *.log
 *.orig
 *.swp
+/.idea

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,0 +1,36 @@
+module.exports = function(grunt) {
+    'use strict';
+
+    require('load-grunt-tasks')(grunt);
+
+    // Project configuration.
+    grunt.initConfig({
+        jsdoc : {
+            dist : {
+                src: ['lib/*.js'],
+                options: {
+                    destination: 'doc'
+                }
+            }
+        },
+        clean: ["doc"],
+        'gh-pages': {
+            options: {
+                base: 'doc'
+            },
+            src: ['**']
+        },
+        eslint: {
+            options: {
+                configFile: '.eslintrc'
+            },
+            target: ['lib/router.js']
+        }
+    });
+
+    //testing tasks
+    grunt.registerTask('docs', 'Default task will create API documentation and test', ['jsdoc', 'gh-pages', 'clean']);
+    grunt.registerTask('test', 'Default task will create API documentation and test', ['eslint']);
+    grunt.registerTask('default', 'Default task will create API documentation and test', ['docs', 'test']);
+
+};

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,13 @@
+Copyright (c) 2015 James Cooke
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/README.md
+++ b/README.md
@@ -72,3 +72,6 @@ To apply the router to your app:
 ```
 accountsRouter.routify(app);
 ```
+### API Documentation
+
+http://cameojokes.github.io/restify-routify

--- a/lib/router.js
+++ b/lib/router.js
@@ -1,6 +1,38 @@
+/**
+ * @author James Cooke
+ * @file restify-routify - Creates nested routify routes
+ * @copyright James Cooke (c) 2015
+ */
+
+/**
+ * @external Restify
+ * @see {@link http://restify.com|Restify}
+ */
+
+/**
+ * @constant idMethods
+ * @desc http methods
+ * @type {string[]}
+ */
 var idMethods = ['del', 'get', 'patch', 'put'];
+
+/**
+ * @constant methods
+ * @desc additional http methods
+ * @type {Array.<string>}
+ */
 var methods = ['list', 'post'].concat(idMethods);
 
+/**
+ * @constructor Router
+ * @desc creates a new Router
+ * @param {string} name - The URL prefix for the router(/[name]).
+ * This argument is optional if you wish to create an extendable router for the root path(/)
+ * @param {string} param - The URL parameter for members of this routes collection(/[name]/:[param]).
+ * This argument is optional, and should only be provided when the router is used for a collection.
+ * @example To create a base router for /accounts:
+ * var accountsRouter = new Router('accounts', 'accountId');
+ */
 function Router(name, param) {
 	this.routes = {
 		del: [],
@@ -15,10 +47,22 @@ function Router(name, param) {
 	this.param = param;
 }
 
+/**
+ * @function extend
+ * @desc Extends a route so you can add more routes to the same restify app
+ * @param {Router} router object instance
+ */
 Router.prototype.extend = function add(router) {
 	var prefix = this.makePath(true);
 	var routes = this.routes;
 
+	/**
+	 * @function eachRoute
+	 * @desc adds route handler and path objects to a route with a method property
+	 * @inner
+	 * @param {string} method - one of del|get|list|patch|post|put
+	 * @param {Object} route - object consisting of an array of handlers and a path
+	 */
 	function eachRoute(method, route) {
 		var path = prefix + route.path;
 
@@ -33,6 +77,11 @@ Router.prototype.extend = function add(router) {
 	router.iterateRoutes(eachRoute.bind(this));
 };
 
+/**
+ * @function iterateRoutes
+ * @desc iterates over array of callbacks assigned to each method
+ * @param {middlewareOrRouteHandlerCallback} cb - a middleware or route handler
+ */
 Router.prototype.iterateRoutes = function iterateRoutes(cb) {
 	methods.forEach(function eachMethod(method) {
 		this.routes[method].forEach(function eachRoute(route) {
@@ -40,8 +89,28 @@ Router.prototype.iterateRoutes = function iterateRoutes(cb) {
 		});
 	}.bind(this));
 };
+/**
+ * @callback middlewareOrRouteHandlerCallback
+ * @description restify compatible middleware or route handler
+ * @param {object} error
+ * @param {object} request
+ * @param {object} response
+ * @param {object} object
+ */
 
+/**
+ * @function routify
+ * @desc applies router to restify app
+ * @param {RestifyServer} app - Restify server app
+ */
 Router.prototype.routify = function setRoutes(app) {
+	/**
+	 * @function eachRoute
+	 * @desc assigns the `list` method to the get HTTP verb
+	 * @inner
+	 * @param {string} method - one of del|get|list|patch|post|put
+	 * @param {Object} route - object consisting of an array of handlers and a path
+	 */
 	function eachRoute(method, route) {
 		var methodLocal = method === 'list' ? 'get' : method;
 		app[methodLocal].apply(app, [route.path].concat(route.handlers));
@@ -49,7 +118,17 @@ Router.prototype.routify = function setRoutes(app) {
 
 	this.iterateRoutes(eachRoute);
 };
+/**
+ * @typedef {Object} RestifyServer
+ * @desc Restify Server app
+ */
 
+/**
+ * @function makePath
+ * @desc takes the URL prefix name and creates a path
+ * @param {boolean} method - method exists
+ * @returns {*}
+ */
 Router.prototype.makePath = function makePath(method) {
 	if (!this.name) {
 		return '';
@@ -66,6 +145,12 @@ Router.prototype.makePath = function makePath(method) {
 };
 
 methods.forEach(function eachMethod(method) {
+	/**
+	 * @function
+	 * @desc dynamic function / factory which creates an object literal
+	 * of handlers and paths for each route object with a method property
+	 * @returns {*}
+	 */
 	Router.prototype[method] = function methodSetter() {
 		var handlers = new Array(arguments.length);
 		var idx;
@@ -83,4 +168,14 @@ methods.forEach(function eachMethod(method) {
 	};
 });
 
+/**
+ * @module
+ * @type {Router}
+ */
 module.exports = Router;
+/**
+ * @typedef {Object} Router
+ * @desc Routerify Router instance
+ */
+
+

--- a/package.json
+++ b/package.json
@@ -6,10 +6,25 @@
   "scripts": {
     "test": "mocha"
   },
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:cameojokes/restify-routify.git"
+  },
+  "bugs": {
+    "url": "https://github.com/cameojokes/restify-routify/issues"
+  },
+  "license": "Apache-2.0",
   "author": "James Cooke",
   "devDependencies": {
     "eslint": "^1.9.0",
     "eslint-config-airbnb": "^1.0.0",
-    "eslint-config-jcooke": "0.0.2"
+    "eslint-config-jcooke": "0.0.2",
+    "grunt": "^0.4.5",
+    "grunt-contrib-clean": "^0.7.0",
+    "grunt-eslint": "^17.3.1",
+    "grunt-gh-pages": "^1.0.0",
+    "grunt-jsdoc": "^1.0.0",
+    "jsdoc": "^3.3.3",
+    "load-grunt-tasks": "^3.3.0"
   }
 }


### PR DESCRIPTION
Also added some more properties to the package.json.

* The jsdocs will get pushed to the gihub pages with the command: `grunt docs`
* eslint will run with `grunt docs`
* `grunt` will do both

Also bumped.

Example of hat your github pages will look like [here](http://html5devgal.com/restify-routify/) (my github pages).  I added a link to the README where your would be, which would be here: http://cameojokes.github.io/restify-routify